### PR TITLE
Pin Python 3.11 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v4.7.1
       with:
-        python-version: '3'
+        python-version: '3.11'
         cache: 'pip'
         cache-dependency-path: |
           requirements.txt
@@ -110,7 +110,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4.7.1
         with:
-          python-version: '3'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
@@ -230,7 +230,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4.7.1
         with:
-          python-version: '3'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt

--- a/.github/workflows/updpyver.yml
+++ b/.github/workflows/updpyver.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4.7.1
         with:
-          python-version: '3'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'requirements.txt'
 


### PR DESCRIPTION
transifex-python doesn't support Python 3.12 yet, failing on pip install. See https://github.com/transifex/transifex-python/issues/106. See also these workflow runs of [updpyver.yml](https://github.com/rffontenelle/python-docs-tx-translations/actions/runs/6667718773/job/18121717863) and [ci.yml](https://github.com/rffontenelle/python-docs-tx-translations/actions/runs/6668346770/job/18123725648).