### PR TITLE
Remove square brackets of regexp in lock-translations.py

### DIFF
--- a/scripts/lock-translations.py
+++ b/scripts/lock-translations.py
@@ -25,7 +25,7 @@ def get_local_resources(tx_config, project):
     config.read(tx_config)
     
     try:
-      project in re.search('p:python-[\w]+:', config.sections()[1]).group(0)
+      project in re.search('p:python-\w+:', config.sections()[1]).group(0)
     except:
       printmsg("error", f"Invalid Transifex configuration file for project '{project}'")
       exit(1)

--- a/scripts/lock-translations.py
+++ b/scripts/lock-translations.py
@@ -25,7 +25,7 @@ def get_local_resources(tx_config, project):
     config.read(tx_config)
     
     try:
-      project in re.search('p:python-\w+:', config.sections()[1]).group(0)
+      project in re.search(r'p:python-\w+:', config.sections()[1]).group(0)
     except:
       printmsg("error", f"Invalid Transifex configuration file for project '{project}'")
       exit(1)


### PR DESCRIPTION
From Actions log

```
> Run python3 scripts/lock-translations.py cpython/Doc/locales/.tx/config python-newest
/home/runner/work/python-docs-tx-translations/python-docs-tx-translations/scripts/lock-translations.py:28: SyntaxWarning: invalid escape sequence '\w'
  project in re.search('p:python-[\w]+:', config.sections()[1]).group(0)
Using TX Config Path: cpython/Doc/locales/.tx/config
Using project: python-newest
Successfully retrieved local resources!
All resources are locked or in use!
```