### PR TITLE
Fix auditing events missing reST markups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,8 @@ jobs:
           pip3 install --upgrade pip
           pip3 install -r requirements.txt -r cpython/Doc/requirements.txt
 
-      - name: Patch to fix cpython issue \#122629
+      - name: Patch to fix cpython issue \#122629 in cpython 3.13
+        if: ${{ matrix.cpython_version == '3.13' }}
         working-directory: cpython
         run: |
           curl https://patch-diff.githubusercontent.com/raw/python/cpython/pull/122653.patch | git apply -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,11 @@ jobs:
           pip3 install --upgrade pip
           pip3 install -r requirements.txt -r cpython/Doc/requirements.txt
 
+      - name: Patch to fix cpython issue \#122629
+        working-directory: cpython
+        run: |
+          curl https://patch-diff.githubusercontent.com/raw/python/cpython/pull/122653.patch | git apply -v
+
       - name: Change Transifex project name if Python version != python-newest
         if: ${{ matrix.cpython_version != needs.trigger.outputs.current }}
         shell: bash


### PR DESCRIPTION
Fix cpython issue 122629, applying the PR 122653

This PR is mostly for me to trigger the CI workflow manually from this specific branch without having to merge the patch into main, as I the linked backport will probably me merged into cpython soon