### PR TITLE
Try ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   trigger:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     outputs:
@@ -81,7 +81,7 @@ jobs:
 
 
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: trigger
     permissions:
       contents: write
@@ -215,7 +215,7 @@ jobs:
 
 
   propagate_translations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [trigger, update]
     permissions:
       contents: read

--- a/.github/workflows/updpyver.yml
+++ b/.github/workflows/updpyver.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out ${{ github.repository }}
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Ubuntu-latest workflows will use Ubuntu-24.04 image.  This change will be rolled out over a period of several weeks beginning December 5th and will complete on January 17th, 2025.