### PR TITLE
Rename project to transifex-automations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
-===========================
-python-docs-tx-translations
-===========================
+=====================
+transifex-automations
+=====================
 
-.. image:: https://github.com/rffontenelle/python-docs-tx-translations/actions/workflows/ci.yml/badge.svg
-   :target: https://github.com/rffontenelle/python-docs-tx-translations/actions/workflows/ci.yml
+.. image:: https://github.com/python-docs-translations/transifex-automations/actions/workflows/ci.yml/badge.svg
+   :target: https://github.com/python-docs-translations/transifex-automations/actions/workflows/ci.yml
 
 Scripts and procedures for maintaining Python_ documentation translation infrastructure under python-doc_ organization in Transifex_.
 
@@ -20,5 +20,5 @@ See Translating_ in Python Developer's Guide for more information.
 .. _Python: https://www.python.org
 .. _python-doc: https://app.transifex.com/python-doc/
 .. _Transifex: https://www.transifex.com
-.. _docs: https://github.com/rffontenelle/docspush-transifex/blob/main/docs/
+.. _docs: https://github.com/python-docs-translations/transifex-automations/blob/main/docs/
 .. _Translating: https://devguide.python.org/documentation/translating/

--- a/docs/bumping-release.rst
+++ b/docs/bumping-release.rst
@@ -2,7 +2,7 @@
 Bumping python-newest to latest Python release
 ====================================================
 
-NOTE: This doc is out of date and needs rework! The `pull request \#13 <https://github.com/rffontenelle/python-docs-tx-translations/pull/13>`_ is a work in progress that would change some instructions from this guide.
+NOTE: This doc is out of date and needs rework! The `pull request \#13 <https://github.com/python-docs-translations/transifex-automations/pull/13>`_ is a work in progress that would change some instructions from this guide.
 
 This document aims to list the steps required for updating version of the 'Python' project (slug 'python-newest) in python-doc organization in Transifex.
 
@@ -40,14 +40,14 @@ In *Workflow* tab, enable the *Translation Memory Fillup* option by checking the
 
     NOTE: The *Translation Memory Fillup* option is essential to have a translation in one of the version projects to be populated to this project. This drastically reduces translation effort replicating one contribution to other strings that are exactly the same.  
 
-6. Adjust the `CI workflow <https://github.com/rffontenelle/python-docs-tx-translations/tree/main/.github/workflows>`_ with the new Python version:
+6. Adjust the `CI workflow <https://github.com/python-docs-translations/transifex-automations/tree/main/.github/workflows>`_ with the new Python version:
 
     #. Set ``PYTHON_NEWEST`` environment variable inside ``env`` to the new Python version
     #. Edit ``cpython_version`` inside ``strategy.matrix`` adding the new version to the beginning array
 
 7. Push source strings to python-newest by manually running the CI workflow: Actions_ tab > CI > Run workflow button > "Branch: main" and confirm "Run workflow"
 
-.. _Actions: https://github.com/rffontenelle/python-docs-tx-translations/actions
+.. _Actions: https://github.com/python-docs-translations/transifex-automations/actions
 
 8. Unlock translations in python-newest, if locked
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'Python Docs Transifex Translations'
+project = 'Python Docs Transifex Automations'
 copyright = '2025, rffontenelle'
 author = 'rffontenelle'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. Python Docs Transifex Translations documentation master file, created by
+.. Python Docs Transifex Automations documentation master file, created by
    sphinx-quickstart on Sun Jan 26 11:03:05 2025.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ See Translating_ in Python Developer's Guide for more information.
 .. _Python: https://www.python.org
 .. _python-doc: https://app.transifex.com/python-doc/
 .. _Transifex: https://www.transifex.com
-.. _docs: https://github.com/rffontenelle/docspush-transifex/blob/main/docs/
+.. _docs: https://github.com/python-docs-translations/transifex-automations/blob/main/docs/
 .. _Translating: https://devguide.python.org/documentation/translating/
 
 .. toctree::

--- a/docs/placeholders.rst
+++ b/docs/placeholders.rst
@@ -48,7 +48,7 @@ To make easier to read the source strings, extract them from the doc files and p
 
 .. code-block:: shell
 
-   git clone https://github.com/rffontenelle/python-docs-tx-translations
+   git clone https://github.com/python-docs-translations/transifex-automations
    cd python-docs-tx-translations
    git clone --depth 1 --branch 3.12 https://github.com/python/cpython
    python -mvenv venv

--- a/scripts/remove-msgid.sh
+++ b/scripts/remove-msgid.sh
@@ -43,7 +43,7 @@ remove_msgid() {
 
 
 # \\N is treated as new line in Transifex, so it is an illegal source string
-# https://github.com/rffontenelle/python-docs-tx-translations/issues/15
+# https://github.com/python-docs-translations/transifex-automations/issues/15
 remove_msgid  library/codecs.pot '^\\N$'
 remove_msgid  library/re.pot  '^\\N$'
 remove_msgid  reference/lexical_analysis.pot  '^\\N$'


### PR DESCRIPTION
This is to fit into [python-docs-translations](https://github.com/python-docs-translations) organization

See #34 

<!-- readthedocs-preview python-docs-tx-translations start -->
----
📚 Documentation preview 📚: https://python-docs-tx-translations--114.org.readthedocs.build/en/114/

<!-- readthedocs-preview python-docs-tx-translations end -->